### PR TITLE
Fix chmod hex numbers

### DIFF
--- a/blackrock_data_fetcher.py
+++ b/blackrock_data_fetcher.py
@@ -110,7 +110,7 @@ def main(argv=None):
 
     # make sure all the images are world readable
     for f in listdir:
-        os.chmod(local_dir + "/" + f, 0o644)
+        os.chmod(local_dir + "/" + f, 0644)
 
     # make a symlink to the most current directory of images
     symlink = symlink = LOCAL_DIRECTORY_BASE + "/current"

--- a/blackrock_photo_fetcher.py
+++ b/blackrock_photo_fetcher.py
@@ -96,8 +96,8 @@ def main(argv=None):
           ])
 
     # make sure the images are world readable
-    os.chmod(local_path, 0o644)
-    os.chmod(local_thumb_path, 0o644)
+    os.chmod(local_path, 0644)
+    os.chmod(local_thumb_path, 0644)
 
     # create a symlink to the most current image
     symlink = LOCAL_WEBCAM_DIRECTORY_BASE + "/current.jpg"


### PR DESCRIPTION
For some reason, I changed this because flake8 was complaining,
and this breaks the behavior. Now it's not complaining anymore.
It must be the newer flake8, which dropped compatibility with
python 2.6 so I downgraded.