### PR TITLE
prepend octal literal with "0o" instead of "0"

### DIFF
--- a/blackrock_data_fetcher.py
+++ b/blackrock_data_fetcher.py
@@ -144,7 +144,7 @@ def main(argv=None):
 
     # make sure all the images are world readable
     for f in listdir:
-        os.chmod(os.path.join(local_dir, f), 0644)
+        os.chmod(os.path.join(local_dir, f), 0o644)
 
     # make a symlink to the most current directory of images
     symlink = os.path.join(LOCAL_DIRECTORY_BASE, 'current')


### PR DESCRIPTION
This adds compatibility with python 3 while still working on python 2.6.

https://www.python.org/dev/peps/pep-3127/