### PR TITLE
Remove python 2.6 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.6"
 script:


### PR DESCRIPTION
I've gotten pyenv set up in the tlcreg user's home directory on cunix, so we can now use whatever python version we want here. I'm currently using 2.7.13.