### PR TITLE
calc_avg(): Convert all numbers to floats before calculation

### DIFF
--- a/blackrock_data_processor.py
+++ b/blackrock_data_processor.py
@@ -11,6 +11,7 @@ except ImportError:
 
 def calc_avg(a):
     """Returns the average of the given list of numbers."""
+    a = list(map(float, a))
     return sum(a) / float(len(a))
 
 


### PR DESCRIPTION
This fixes an error that occurs if any of these numbers is a string.